### PR TITLE
Add AppImage packaging for Linux

### DIFF
--- a/.github/workflows/ci_linux.yml
+++ b/.github/workflows/ci_linux.yml
@@ -1,0 +1,84 @@
+name: CI-Linux
+
+on:
+  push:
+    branches:
+      - master
+    paths-ignore:
+      - 'README.md'
+  pull_request:
+    branches:
+      - master
+    paths-ignore:
+      - 'README.md'
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+
+    steps:
+    - name: Checkout
+      uses: actions/checkout@v4
+      with:
+        fetch-depth: 0
+
+    - name: Install Qt
+      uses: jurplel/install-qt-action@v3
+      with:
+        version: '6.6'
+        modules: 'qtmultimedia'
+
+    - name: Install build dependencies
+      env:
+        FFMPEG_DEPS: >
+          libavutil-dev
+          libavcodec-dev
+          libavformat-dev
+          libavfilter-dev
+          libswscale-dev
+          libswresample-dev
+          libfuse2
+        APPIMAGE_DEPS: >
+          libfuse2
+          libxcb-cursor0
+      run: sudo apt install -y $FFMPEG_DEPS $APPIMAGE_DEPS
+
+    - name: Build
+      run: |
+        cmake -B ${{github.workspace}}/build -DCMAKE_BUILD_TYPE=Release
+        cmake --build ${{github.workspace}}/build
+
+    - name: Install linuxdeploy
+      run: |
+        wget https://github.com/linuxdeploy/linuxdeploy/releases/download/continuous/linuxdeploy-x86_64.AppImage
+        wget https://github.com/linuxdeploy/linuxdeploy-plugin-qt/releases/download/continuous/linuxdeploy-plugin-qt-x86_64.AppImage
+        chmod +x linuxdeploy-x86_64.AppImage
+        chmod +x linuxdeploy-plugin-qt-x86_64.AppImage
+
+    - name: Build AppImage
+      # Qt6_DIR is set by the install-qt-action
+      run: >
+        QMAKE=$Qt6_DIR/bin/qmake
+        PATH=$Qt6_DIR/libexec:$PATH
+        ./linuxdeploy-x86_64.AppImage
+        --appdir AppDir
+        -e ${{github.workspace}}/build/app/si-edit
+        -i ${{github.workspace}}/app/res/icon.svg
+        -d ${{github.workspace}}/app/res/AppImage.desktop
+        --plugin qt
+        --output appimage
+
+    - name: 'Upload Artifact: libweaver'
+      uses: actions/upload-artifact@v4
+      with:
+        name: libweaver-Linux
+        path: ${{github.workspace}}/build/lib/libweaver.so
+        if-no-files-found: error
+
+    - name: 'Upload Artifact: AppImage'
+      uses: actions/upload-artifact@v4
+      with:
+        name: SI-Edit-Linux.AppImage
+        path: ${{github.workspace}}/SI_Edit*.AppImage
+        if-no-files-found: error
+

--- a/app/res/AppImage.desktop
+++ b/app/res/AppImage.desktop
@@ -1,0 +1,9 @@
+[Desktop Entry]
+Name=SI Edit
+Comment=Tool for working with SI files
+Exec=si-edit
+Terminal=false
+Type=Application
+Icon=icon
+Categories=Development;Graphics;AudioVideo;
+

--- a/lib/CMakeLists.txt
+++ b/lib/CMakeLists.txt
@@ -27,6 +27,7 @@ endif()
 set_target_properties(libweaver PROPERTIES
   CXX_STANDARD 98
   CXX_STANDARD_REQUIRED ON
+  PREFIX ""
 )
 
 if(LIBWEAVER_BUILD_DOXYGEN)


### PR DESCRIPTION
This adds a new workflow that builds an AppImage. It creates 2 artifacts: libweaver.so and an AppImage for the GUI app. The artifacts are available for each run, but are not uploaded to the releases.

This is also a separate workflow from the windows one (ci.yaml) because that one had some problems currently. They can be combined in the future, but this can be a starting point now.

This is also my first time playing around with the github workflows so any feedback is appreciated! Mostly followed the [workflow of Serial-Studio](https://github.com/Serial-Studio/Serial-Studio/blob/master/.github/workflows/deploy.yml)