### PR TITLE
app: presentation tweaks and improvements

### DIFF
--- a/app/main.cpp
+++ b/app/main.cpp
@@ -40,6 +40,7 @@ int main(int argc, char *argv[])
   qInstallMessageHandler(DebugHandler);
 
   QApplication a(argc, argv);
+  a.setApplicationName(QObject::tr("SI Editor"));
 
   MainWindow w;
 

--- a/app/mainwindow.cpp
+++ b/app/mainwindow.cpp
@@ -303,6 +303,8 @@ void MainWindow::TrimOffDirectory(QString& s)
 
 void MainWindow::NewFile()
 {
+  tree_->clearSelection();
+  SetPanel(panel_blank_, nullptr);
   model_.SetCore(nullptr);
   interleaf_.Clear();
   model_.SetCore(&interleaf_);

--- a/app/mainwindow.cpp
+++ b/app/mainwindow.cpp
@@ -1,5 +1,6 @@
 #include "mainwindow.h"
 
+#include <QApplication>
 #include <QFileDialog>
 #include <QLineEdit>
 #include <QMenuBar>
@@ -104,7 +105,7 @@ MainWindow::MainWindow(QWidget *parent) :
 
   splitter->setSizes({99999, 99999});
 
-  setWindowTitle(tr("SI Editor"));
+  setWindowTitle(QApplication::applicationName());
 }
 
 void MainWindow::OpenFilename(const QString &s)
@@ -183,11 +184,7 @@ void MainWindow::ExtractObject(si::Object *obj)
     filename = QString::fromStdString(obj->name());
     filename.append(QStringLiteral(".bin"));
   } else {
-    // Strip off directory
-    int index = filename.lastIndexOf('\\');
-    if (index != -1) {
-      filename = filename.mid(index+1);
-    }
+    TrimOffDirectory(filename);
   }
 
   QString s = QFileDialog::getSaveFileName(this, tr("Export Object"), filename);
@@ -278,6 +275,17 @@ bool MainWindow::ExtractAllRecursiveInternal(const QDir &dir, const si::Core *ob
   return true;
 }
 
+void MainWindow::TrimOffDirectory(QString& s)
+{
+  int bSlashIndex = s.lastIndexOf('\\');
+  int fSlashIndex = s.lastIndexOf('/');
+  int lastIndex = (bSlashIndex > fSlashIndex) ? bSlashIndex : fSlashIndex;
+
+  if (lastIndex != -1) {
+    s = s.mid(lastIndex + 1);
+  }
+}
+
 void MainWindow::NewFile()
 {
   model_.SetCore(nullptr);
@@ -290,6 +298,9 @@ void MainWindow::OpenFile()
   QString s = GetOpenFileName();
   if (!s.isEmpty()) {
     OpenFilename(s);
+    TrimOffDirectory(s);
+
+    setWindowTitle(QStringLiteral("%1 - %2").arg(QApplication::applicationName(), s));
   }
 }
 

--- a/app/mainwindow.cpp
+++ b/app/mainwindow.cpp
@@ -177,6 +177,23 @@ void MainWindow::SetPanel(Panel *panel, si::Object *chunk)
   }
 }
 
+void MainWindow::UpdateWindowTitleFlag(bool isFileModified)
+{
+  QString title = windowTitle();
+
+  if (isFileModified) {
+    if (!title.endsWith("*")) {
+      title.append("*");
+      setWindowTitle(title);
+    }
+  } else {
+    if (title.endsWith("*")) {
+      // trim off asterisk
+      setWindowTitle(title.left(title.length() - 1));
+    }
+  }
+}
+
 void MainWindow::ExtractObject(si::Object *obj)
 {
   QString filename = QString::fromStdString(obj->filename());
@@ -213,6 +230,7 @@ void MainWindow::ReplaceObject(si::Object *obj)
 #endif
         )) {
       static_cast<Panel*>(config_stack_->currentWidget())->ResetData();
+      UpdateWindowTitleFlag(true);
     } else {
       QMessageBox::critical(this, QString(), tr("Failed to open to file \"%1\".").arg(s));
     }
@@ -318,6 +336,7 @@ bool MainWindow::SaveFile()
     );
 
     if (r == Interleaf::ERROR_SUCCESS) {
+      UpdateWindowTitleFlag(false);
       return true;
     } else {
       QMessageBox::critical(this, QString(), tr("Failed to write SI file: %1").arg(r));

--- a/app/mainwindow.cpp
+++ b/app/mainwindow.cpp
@@ -177,21 +177,18 @@ void MainWindow::SetPanel(Panel *panel, si::Object *chunk)
   }
 }
 
-void MainWindow::UpdateWindowTitleFlag(bool isFileModified)
+void MainWindow::UpdateWindowTitle(QString filename)
+{
+  TrimOffDirectory(filename);
+  setWindowTitle(QStringLiteral("%1 - %2").arg(QApplication::applicationName(), filename));
+}
+
+void MainWindow::AppendModifiedTitleIndicator()
 {
   QString title = windowTitle();
+  title.append("*");
 
-  if (isFileModified) {
-    if (!title.endsWith("*")) {
-      title.append("*");
-      setWindowTitle(title);
-    }
-  } else {
-    if (title.endsWith("*")) {
-      // trim off asterisk
-      setWindowTitle(title.left(title.length() - 1));
-    }
-  }
+  setWindowTitle(title);
 }
 
 void MainWindow::ExtractObject(si::Object *obj)
@@ -230,7 +227,7 @@ void MainWindow::ReplaceObject(si::Object *obj)
 #endif
         )) {
       static_cast<Panel*>(config_stack_->currentWidget())->ResetData();
-      UpdateWindowTitleFlag(true);
+      AppendModifiedTitleIndicator();
     } else {
       QMessageBox::critical(this, QString(), tr("Failed to open to file \"%1\".").arg(s));
     }
@@ -309,6 +306,8 @@ void MainWindow::NewFile()
   model_.SetCore(nullptr);
   interleaf_.Clear();
   model_.SetCore(&interleaf_);
+
+  UpdateWindowTitle(tr("UNTITLED.SI"));
 }
 
 void MainWindow::OpenFile()
@@ -316,9 +315,7 @@ void MainWindow::OpenFile()
   QString s = GetOpenFileName();
   if (!s.isEmpty()) {
     OpenFilename(s);
-    TrimOffDirectory(s);
-
-    setWindowTitle(QStringLiteral("%1 - %2").arg(QApplication::applicationName(), s));
+    UpdateWindowTitle(s);
   }
 }
 
@@ -336,7 +333,7 @@ bool MainWindow::SaveFile()
     );
 
     if (r == Interleaf::ERROR_SUCCESS) {
-      UpdateWindowTitleFlag(false);
+      UpdateWindowTitle(current_filename_);
       return true;
     } else {
       QMessageBox::critical(this, QString(), tr("Failed to write SI file: %1").arg(r));

--- a/app/mainwindow.h
+++ b/app/mainwindow.h
@@ -29,7 +29,6 @@ private:
   void InitializeMenuBar();
 
   void SetPanel(Panel *panel, si::Object *chunk);
-  void UpdateWindowTitleFlag(bool isFileModified);
 
   void ExtractObject(si::Object *obj);
   void ReplaceObject(si::Object *obj);
@@ -41,6 +40,9 @@ private:
   bool ExtractAllRecursiveInternal(const QDir &dir, const si::Core *obj);
 
   void TrimOffDirectory(QString &s);
+
+  void UpdateWindowTitle(QString filename);
+  void AppendModifiedTitleIndicator();
 
   static const QString kFileFilter;
 

--- a/app/mainwindow.h
+++ b/app/mainwindow.h
@@ -39,6 +39,8 @@ private:
 
   bool ExtractAllRecursiveInternal(const QDir &dir, const si::Core *obj);
 
+  void TrimOffDirectory(QString &s);
+
   static const QString kFileFilter;
 
   QStackedWidget *config_stack_;

--- a/app/mainwindow.h
+++ b/app/mainwindow.h
@@ -29,6 +29,7 @@ private:
   void InitializeMenuBar();
 
   void SetPanel(Panel *panel, si::Object *chunk);
+  void UpdateWindowTitleFlag(bool isFileModified);
 
   void ExtractObject(si::Object *obj);
   void ReplaceObject(si::Object *obj);


### PR DESCRIPTION
This PR includes some general presentation tweaks and improvements:

- Sets the global application title to "SI Editor" and reuses it for the window title (previously, only the window title was set to "SI Editor").
- Appends the currently opened Interleaf file name to the window title.
- Adds an asterisk indicator to the filename in the title if the file has pending unsaved changes.
- Properly clears/initializes the screen when making a new file (previously, the media panel elements would remain).