### PR TITLE
QImage::mirrored is deprecated, swapped to Qt::Vertical.

### DIFF
--- a/app/viewer/mediapanel.cpp
+++ b/app/viewer/mediapanel.cpp
@@ -302,7 +302,7 @@ void MediaPanel::VideoUpdate(float t)
         auto v = m_imgViewers.at(i);
 
         if (v->property("vflip").toBool()) {
-          img = img.mirrored(false, true);
+          img = img.flipped(Qt::Vertical);
         }
 
         v->setPixmap(QPixmap::fromImage(img));


### PR DESCRIPTION
Building provides this warning, Qt6 deprecates `QImage::mirrored`.

Instead we now need to use either
 * `flipped(Qt::Vertical)`
 * `flipped(Qt::Horizontal)`

```
/home/paul/aur/si-edit-git/src/SIEdit/app/viewer/mediapanel.cpp: In member function ‘void MediaPanel::VideoUpdate(float)’:
/home/paul/aur/si-edit-git/src/SIEdit/app/viewer/mediapanel.cpp:305:29: error: ‘QImage QImage::mirrored(bool, bool) const &’ is deprecated: Use flipped(Qt::Orientations) instead [-Werror=deprecated-declarations]
  305 |           img = img.mirrored(false, true);
      |                 ~~~~~~~~~~~~^~~~~~~~~~~~~
In file included from /usr/include/qt6/QtGui/qpixmap.h:13,
                 from /usr/include/qt6/QtGui/qicon.h:10,
                 from /usr/include/qt6/QtWidgets/qabstractbutton.h:8,
                 from /usr/include/qt6/QtWidgets/qcheckbox.h:8,
                 from /usr/include/qt6/QtWidgets/QCheckBox:1,
                 from /home/paul/aur/si-edit-git/src/SIEdit/app/viewer/mediapanel.h:17,
                 from /home/paul/aur/si-edit-git/src/SIEdit/app/viewer/mediapanel.cpp:1:
/usr/include/qt6/QtGui/qimage.h:220:26: note: declared here
  220 |     [[nodiscard]] QImage mirrored(bool horizontally = false, bool vertically = true) const &
      |                          ^~~~~~~~
cc1plus: all warnings being treated as errors
make[2]: *** [app/CMakeFiles/si-edit.dir/build.make:142: app/CMakeFiles/si-edit.dir/viewer/mediapanel.cpp.o] Error 1
make[1]: *** [CMakeFiles/Makefile2:165: app/CMakeFiles/si-edit.dir/all] Error 2
make: *** [Makefile:91: all] Error 2
```