### PR TITLE
Add icon to SIedit app

### DIFF
--- a/app/CMakeLists.txt
+++ b/app/CMakeLists.txt
@@ -37,6 +37,7 @@ set(PROJECT_SOURCES
   vector3edit.h
 
   res/res.rc
+  res/icons.qrc
 )
 
 if(${QT_VERSION_MAJOR} GREATER_EQUAL 6)

--- a/app/mainwindow.cpp
+++ b/app/mainwindow.cpp
@@ -105,6 +105,7 @@ MainWindow::MainWindow(QWidget *parent) :
   splitter->setSizes({99999, 99999});
 
   setWindowTitle(tr("SI Editor"));
+  setWindowIcon(QIcon(QString("://icon.svg")));
 
   SetPanel(panel_blank_, nullptr);
 }

--- a/app/res/icons.qrc
+++ b/app/res/icons.qrc
@@ -1,0 +1,7 @@
+<RCC>
+  <qresource prefix="/">
+    <file>icon1024x1024.png</file>
+    <file>icon.ico</file>
+    <file>icon.svg</file>
+  </qresource>
+</RCC>


### PR DESCRIPTION
The `icon.svg` icon included was not being made as the application icon. This PR adds it as the app icon.

<img width="935" height="510" alt="image" src="https://github.com/user-attachments/assets/a2cec4b5-35d6-4263-9d92-d87627fb6caa" />
<img width="60" height="46" alt="image" src="https://github.com/user-attachments/assets/d0e6d445-233b-460c-b128-4ca5cfb6ba50" />
